### PR TITLE
Add clearStatuses method

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -49,4 +49,9 @@ trait HasStatuses
 
         return $this->statuses()->whereIn('name', $names)->latest()->orderByDesc('id')->first();
     }
+
+    public function clearStatuses(): ?bool
+    {
+        return $this->statuses()->delete();
+    }
 }

--- a/tests/HasStatusesFunctionsTest.php
+++ b/tests/HasStatusesFunctionsTest.php
@@ -179,4 +179,17 @@ class HasStatusesFunctionsTest extends TestCase
 
         $this->testUser->setStatus('pending', 'waiting on action');
     }
+
+    /** @test */
+    public function it_can_delete_statuses_from_a_model()
+    {
+        $this->testUser->setStatus('pending');
+        $this->testUser->setStatus('rejected');
+
+        $this->assertEquals('rejected', $this->testUser->status()->name);
+
+        $this->testUser->clearStatuses();
+
+        $this->assertNull($this->testUser->status());
+    }
 }


### PR DESCRIPTION
This method deletes all statuses when called to prevent the database from cluttering. In time this method could be expanded to delete all statuses for a given name too.
I have added a test for the method, I think it tests the method sufficiently.