### PR TITLE
Remove unneeded use declaration

### DIFF
--- a/src/Exceptions/InvalidStatusModel.php
+++ b/src/Exceptions/InvalidStatusModel.php
@@ -3,7 +3,6 @@
 namespace Spatie\ModelStatus\Exceptions;
 
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 
 class InvalidStatusModel extends Exception
 {

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -43,7 +43,7 @@ class HasStatusesTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_setting_an_invalid_model()
+    public function it_throws_an_exception_when_setting_an_invalid_status()
     {
         $validationUser = ValidationTestModel::create([
             'name' => 'name',


### PR DESCRIPTION
I was walking through the code to understand how the package works and found that line there.

Then, while looking at the tests to make sure I was not missing anything before removing the line I thought that small change in the method name helped clarify things a little bit.