### PR TITLE
add an ability to find models not only by single status, but multiple too

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ The `currentStatus` scope will return models that have a status with the given n
 
 ```php
 $allPendingModels = Model::currentStatus('pending');
+
+//or array of statuses
+$allPendingModels = Model::currentStatus(['pending', 'initiated']);
+$allPendingModels = Model::currentStatus('pending', 'initiated');
 ```
 
 ### Retrieving models without a given state

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -53,15 +53,16 @@ trait HasStatuses
         return $statuses->whereIn('name', $names)->first();
     }
 
-    public function scopeCurrentStatus(Builder $builder, string $name)
+    public function scopeCurrentStatus(Builder $builder, ...$names)
     {
+        $names = is_array($names) ? array_flatten($names) : func_get_args();
         $builder
             ->whereHas('statuses',
-                function (Builder $query) use ($name) {
+                function (Builder $query) use ($names) {
                     $query
-                        ->where('name', $name)
+                        ->whereIn('name', $names)
                         ->whereIn('id',
-                            function (QueryBuilder $query) use ($name) {
+                            function (QueryBuilder $query) {
                                 $query
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -218,6 +218,10 @@ class HasStatusesTest extends TestCase
         $this->assertEquals(
             [],
             TestModel::currentStatus('status-d')->get()->pluck('name')->toArray());
+
+        $this->assertEquals(
+            ['model2', 'model4'],
+            TestModel::currentStatus('status-c', 'status-a')->get()->pluck('name')->toArray());
     }
 
     /** @test */


### PR DESCRIPTION
now you can pass many statuses to Model::currentStatus() scope