### PR TITLE
Add support for custom polymorphic model types

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\ModelStatus\Events\StatusUpdated;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -66,7 +67,7 @@ trait HasStatuses
                                 $query
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
-                                    ->where('model_type', static::class)
+                                    ->where('model_type', $this->getStatusModelType())
                                     ->groupBy('model_id');
                             });
                 });
@@ -90,7 +91,7 @@ trait HasStatuses
                                 $query
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
-                                    ->where('model_type', static::class)
+                                    ->where('model_type', $this->getStatusModelType())
                                     ->groupBy('model_id');
                             });
                 })
@@ -126,5 +127,10 @@ trait HasStatuses
     protected function getStatusModelClassName(): string
     {
         return config('model-status.status_model');
+    }
+
+    protected function getStatusModelType(): string
+    {
+        return array_search(static::class, Relation::morphMap()) ?: static::class;
     }
 }

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -5,6 +5,7 @@ namespace Spatie\ModelStatus\Tests;
 use Illuminate\Support\Facades\DB;
 use Spatie\ModelStatus\Tests\Models\TestModel;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\ModelStatus\Tests\Models\ValidationTestModel;
 use Spatie\ModelStatus\Tests\Models\AlternativeStatusModel;
 
@@ -258,5 +259,15 @@ class HasStatusesTest extends TestCase
         $this->assertCount(4, TestModel::otherCurrentStatus('initiated')->get());
         $this->assertCount(3, TestModel::otherCurrentStatus('initiated', 'pending')->get());
         $this->assertCount(3, TestModel::otherCurrentStatus(['initiated', 'pending'])->get());
+    }
+
+    /** @test */
+    public function it_supports_custom_polymorphic_model_types()
+    {
+        Relation::morphMap(['custom-test-model' => TestModel::class]);
+
+        $this->testModel->setStatus('initiated');
+
+        $this->assertCount(1, TestModel::currentStatus('initiated')->get());
     }
 }


### PR DESCRIPTION
Mapping polymorphic models to custom names with `Relation::morphMap()` works now.