### PR TITLE
Allow custom column name instead of `model_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ return [
      */
     'status_model' => Spatie\ModelStatus\Status::class,
 
+    /*
+     * The name of the column which holds the ID of the model related to the statuses.
+     *
+     * You can change this value if you have set a different name in the migration for the statuses table.
+     */
+    'model_primary_key_attribute' => 'model_id',
+
 ];
 ```
 
@@ -193,6 +200,9 @@ $e->getOldStatus()
 ### Custom model and migration
 
 You can change the model used by specifying a class name in the `status_model` key of the `model-status` config file. 
+
+You can change the column name used in the status table (`model_id` by default) when using a custom migration where you changed 
+that. In that case, simply change the `model_primary_key_attribute` key of the `model-status` config file. 
 
 ### Testing
 

--- a/config/model-status.php
+++ b/config/model-status.php
@@ -9,4 +9,10 @@ return [
      */
     'status_model' => Spatie\ModelStatus\Status::class,
 
+    /*
+     * The name of the column which holds the ID of the model related to the statuses.
+     *
+     * You can change this value if you have set a different name in the migration for the statuses table.
+     */
+    'model_primary_key_attribute' => 'model_id',
 ];

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -14,7 +14,8 @@ trait HasStatuses
 
     public function statuses(): MorphMany
     {
-        return $this->morphMany($this->getStatusModelClassName(), 'model')->latest();
+        return $this->morphMany($this->getStatusModelClassName(), 'model', 'model_type', $this->getModelKeyColumnName())
+                    ->latest();
     }
 
     public function status(): ?Status
@@ -67,7 +68,7 @@ trait HasStatuses
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', static::class)
-                                    ->groupBy('model_id');
+                                    ->groupBy($this->getModelKeyColumnName());
                             });
                 });
     }
@@ -91,7 +92,7 @@ trait HasStatuses
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', static::class)
-                                    ->groupBy('model_id');
+                                    ->groupBy($this->getModelKeyColumnName());
                             });
                 })
             ->orWhereDoesntHave('statuses');
@@ -107,7 +108,7 @@ trait HasStatuses
         $oldStatus = $this->status;
 
         $this->statuses()->create([
-            'name' => $name,
+            'name'   => $name,
             'reason' => $reason,
         ]);
 
@@ -124,6 +125,11 @@ trait HasStatuses
         $modelClass = $this->getStatusModelClassName();
 
         return (new $modelClass)->getTable();
+    }
+
+    protected function getModelKeyColumnName(): string
+    {
+        return config('model-status.model_primary_key_attribute') ?? 'model_id';
     }
 
     protected function getStatusModelClassName(): string

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\ModelStatus\Tests;
 
-use Spatie\ModelStatus\Tests\Models\TestModel;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
-use Spatie\ModelStatus\Tests\Models\ValidationTestModel;
 use Spatie\ModelStatus\Tests\Models\AlternativeStatusModel;
+use Spatie\ModelStatus\Tests\Models\TestModel;
+use Spatie\ModelStatus\Tests\Models\ValidationTestModel;
 
 class HasStatusesTest extends TestCase
 {

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\ModelStatus\Tests;
 
-use Spatie\ModelStatus\Tests\Models\TestModel;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
-use Spatie\ModelStatus\Tests\Models\ValidationTestModel;
 use Spatie\ModelStatus\Tests\Models\AlternativeStatusModel;
+use Spatie\ModelStatus\Tests\Models\CustomModelKeyStatusModel;
+use Spatie\ModelStatus\Tests\Models\TestModel;
+use Spatie\ModelStatus\Tests\Models\ValidationTestModel;
 
 class HasStatusesTest extends TestCase
 {

--- a/tests/Models/CustomModelKeyStatusModel.php
+++ b/tests/Models/CustomModelKeyStatusModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\ModelStatus\Tests\Models;
+
+use Spatie\ModelStatus\Status;
+
+class CustomModelKeyStatusModel extends Status
+{
+    protected $table = 'custom_model_key_statuses';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,6 +37,18 @@ class TestCase extends BaseTestCase
             $table->timestamps();
         });
 
+        $this->app['db']->connection()->getSchemaBuilder()->create('custom_model_key_statuses', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->text('reason')->nullable();
+
+            $this->string("model_type");
+            $this->unsignedBigInteger("model_custom_fk");
+            $this->index(["model_type", "model_custom_fk"]);
+
+            $table->timestamps();
+        });
+
         include_once __DIR__.'/../database/migrations/create_statuses_table.php.stub';
 
         (new CreateStatusesTable())->up();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUpDatabase()
     {
-        tap($this->app['db']->connection()->getSchemaBuilder(), function($schema) {
+        tap($this->app['db']->connection()->getSchemaBuilder(), function ($schema) {
 
             $schema->create('test_models', function (Blueprint $table) {
                 $table->increments('id');
@@ -44,9 +44,9 @@ abstract class TestCase extends BaseTestCase
                 $table->string('name');
                 $table->text('reason')->nullable();
 
-                $table->string("model_type");
-                $table->unsignedBigInteger("model_custom_fk");
-                $table->index(["model_type", "model_custom_fk"]);
+                $table->string('model_type');
+                $table->unsignedBigInteger('model_custom_fk');
+                $table->index(['model_type', 'model_custom_fk']);
 
                 $table->timestamps();
             });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,28 +25,31 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUpDatabase()
     {
-        $this->app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->timestamps();
-        });
+        tap($this->app['db']->connection()->getSchemaBuilder(), function($schema) {
 
-        $this->app['db']->connection()->getSchemaBuilder()->create('validation_test_models', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->timestamps();
-        });
+            $schema->create('test_models', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->timestamps();
+            });
 
-        $this->app['db']->connection()->getSchemaBuilder()->create('custom_model_key_statuses', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->text('reason')->nullable();
+            $schema->create('validation_test_models', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->timestamps();
+            });
 
-            $table->string("model_type");
-            $table->unsignedBigInteger("model_custom_fk");
-            $table->index(["model_type", "model_custom_fk"]);
+            $schema->create('custom_model_key_statuses', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->text('reason')->nullable();
 
-            $table->timestamps();
+                $table->string("model_type");
+                $table->unsignedBigInteger("model_custom_fk");
+                $table->index(["model_type", "model_custom_fk"]);
+
+                $table->timestamps();
+            });
         });
 
         include_once __DIR__.'/../database/migrations/create_statuses_table.php.stub';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,9 +42,9 @@ class TestCase extends BaseTestCase
             $table->string('name');
             $table->text('reason')->nullable();
 
-            $this->string("model_type");
-            $this->unsignedBigInteger("model_custom_fk");
-            $this->index(["model_type", "model_custom_fk"]);
+            $table->string("model_type");
+            $table->unsignedBigInteger("model_custom_fk");
+            $table->index(["model_type", "model_custom_fk"]);
 
             $table->timestamps();
         });


### PR DESCRIPTION
This is a PR regarding https://github.com/spatie/laravel-model-status/issues/39

Let me know if any changes are required