### PR TITLE
Allow null as default reason for status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-model-status` will be documented in this file
 
+## 1.6.1 - 2018-07-19
+
+- Use `null` as default for $reason on statuses
+
 ## 1.6.0 - 2018-07-19
 
 - add model id config option

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $allNonInitiatedOrPendingModels = Model::otherCurrentStatus('initiated', 'pendin
 You can add custom validation when setting a status by overwriting the `isValidStatus` method:
 
 ```php
-public function isValidStatus(string $name, string $description = ''): bool
+public function isValidStatus(string $name, ?string $reason = null): bool
 {
     ...
 

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -23,7 +23,7 @@ trait HasStatuses
         return $this->latestStatus();
     }
 
-    public function setStatus(string $name, string $reason = ''): self
+    public function setStatus(string $name, ?string $reason = null): self
     {
         if (! $this->isValidStatus($name, $reason)) {
             throw InvalidStatus::create($name);
@@ -32,7 +32,7 @@ trait HasStatuses
         return $this->forceSetStatus($name, $reason);
     }
 
-    public function isValidStatus(string $name, string $reason = ''): bool
+    public function isValidStatus(string $name, ?string $reason = null): bool
     {
         return true;
     }
@@ -59,19 +59,23 @@ trait HasStatuses
     {
         $names = is_array($names) ? array_flatten($names) : func_get_args();
         $builder
-            ->whereHas('statuses',
+            ->whereHas(
+                'statuses',
                 function (Builder $query) use ($names) {
                     $query
                         ->whereIn('name', $names)
-                        ->whereIn('id',
+                        ->whereIn(
+                            'id',
                             function (QueryBuilder $query) {
                                 $query
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', $this->getStatusModelType())
                                     ->groupBy($this->getModelKeyColumnName());
-                            });
-                });
+                            }
+                        );
+                }
+            );
     }
 
     /**
@@ -83,19 +87,23 @@ trait HasStatuses
     {
         $names = is_array($names) ? array_flatten($names) : func_get_args();
         $builder
-            ->whereHas('statuses',
+            ->whereHas(
+                'statuses',
                 function (Builder $query) use ($names) {
                     $query
                         ->whereNotIn('name', $names)
-                        ->whereIn('id',
+                        ->whereIn(
+                            'id',
                             function (QueryBuilder $query) use ($names) {
                                 $query
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', $this->getStatusModelType())
                                     ->groupBy($this->getModelKeyColumnName());
-                            });
-                })
+                            }
+                        );
+                }
+            )
             ->orWhereDoesntHave('statuses');
     }
 
@@ -104,7 +112,7 @@ trait HasStatuses
         return (string) $this->latestStatus();
     }
 
-    public function forceSetStatus(string $name, string $reason = ''): self
+    public function forceSetStatus(string $name, ?string $reason = null): self
     {
         $oldStatus = $this->latestStatus();
 


### PR DESCRIPTION
Hello 👋  

A minor change proposed here which would allow `null` as the default `$reason` rather than an empty '' string. Also, I think `null` represents an absence of reason a little better. We also get a _very minor_ space win using null over empty string in storage.

In the migration, you already specify nullable as default, this just mirrors that in the code.
https://github.com/spatie/laravel-model-status/blob/master/database/migrations/create_statuses_table.php.stub#L14

Thanks for creating yet another awesome package!

