### PR TITLE
Publish migration only if do not exist

### DIFF
--- a/src/ModelStatusServiceProvider.php
+++ b/src/ModelStatusServiceProvider.php
@@ -13,7 +13,7 @@ class ModelStatusServiceProvider extends ServiceProvider
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations/');
         }
 
-        if (! class_exists('CreateStatusesTable')) {
+        if (! count(glob(database_path('migrations/*create_statuses_table.php')))) {
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([


### PR DESCRIPTION
Seems like the migrations are not autoloaded by the default composer.json Laravel configuration, so:

https://github.com/spatie/laravel-model-status/blob/master/src/ModelStatusServiceProvider.php#L16

This is always `false` and the migration is published over and over again. Tricky when using this package in an installer.