### PR TITLE
Performance update: using 'whereColumn' instead of 'groupBy' in the Query Scopes

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -72,7 +72,7 @@ trait HasStatuses
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', $this->getStatusModelType())
-                                    ->groupBy($this->getModelKeyColumnName());
+                                    ->whereColumn($this->getModelKeyColumnName(), $this->getQualifiedKeyName());
                             }
                         );
                 }
@@ -100,7 +100,7 @@ trait HasStatuses
                                     ->select(DB::raw('max(id)'))
                                     ->from($this->getStatusTableName())
                                     ->where('model_type', $this->getStatusModelType())
-                                    ->groupBy($this->getModelKeyColumnName());
+                                    ->whereColumn($this->getModelKeyColumnName(), $this->getQualifiedKeyName());
                             }
                         );
                 }


### PR DESCRIPTION
We populated a `statuses` table with more than 400.000 entries and measured the performance of the `CurrentStatus` scope. We looped through the query 100 times (on a Macbook) and the average query time went from 25578.29 ms to 4.3956 ms 🎉