### PR TITLE
Ability to control if the the related model should be touched

### DIFF
--- a/config/model-status.php
+++ b/config/model-status.php
@@ -15,4 +15,10 @@ return [
      * You can change this value if you have set a different name in the migration for the statuses table.
      */
     'model_primary_key_attribute' => 'model_id',
+
+    /*
+     * Control if the model that has the HasStatuses Trait should be touched when setting a Status.
+     * Touched refers: to update the model's updated_at timestamp column.
+     */
+    'touches_model' => false,
 ];

--- a/config/model-status.php
+++ b/config/model-status.php
@@ -18,7 +18,7 @@ return [
 
     /*
      * Control if the model that has the HasStatuses Trait should be touched when setting a Status.
-     * Touched refers: to update the model's updated_at timestamp column.
+     * Touched refers to: update the model's updated_at timestamp column when a Status is set.
      */
     'touches_model' => false,
 ];

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -122,6 +122,10 @@ trait HasStatuses
             'reason' => $reason,
         ]);
 
+        if (config('model-status.touches_model')) {
+            $this->touch();
+        }
+
         event(new StatusUpdated($oldStatus, $newStatus, $this));
 
         return $this;

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -122,7 +122,9 @@ trait HasStatuses
             'reason' => $reason,
         ]);
 
-        if (config('model-status.touches_model')) {
+        $touches_model = config('model-status.touches_model');
+
+        if ($touches_model) {
             $this->touch();
         }
 


### PR DESCRIPTION
This PR introduces a new configuration option in the model-status.php config file.

With it you can control if the model that has the HasStatuses Trait should be 
touched when setting a Status. Touched refers to: update the model's updated_at timestamp column when a Status is set.

The configuration option is set to false, by default.

```
/*
* Control if the model that has the HasStatuses Trait should be touched when setting a Status.
* Touched refers to: update the model's updated_at timestamp column when a Status is set.
*/
    'touches_model' => false,
```

Disclaimer: 
People upgrading should re-publish the configuration file.