### PR TITLE
Add possibility to delete a status and check for specific status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .php_cs.cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-model-status.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-model-status)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-model-status.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-model-status)
 
-Imagine you want to have an Eloquent model hold a status. It's easily solved by just adding a `status` field to that model and be done with it. But in case you need a history of status changes or need to store some extra info on why a status changed, just adding a single field won't cut it. 
+Imagine you want to have an Eloquent model hold a status. It's easily solved by just adding a `status` field to that model and be done with it. But in case you need a history of status changes or need to store some extra info on why a status changed, just adding a single field won't cut it.
 
 This package provides a `HasStatuses` trait that, once installed on a model, allows you to do things like this:
 
@@ -60,7 +60,7 @@ return [
 
     /*
      * The class name of the status model that holds all statuses.
-     * 
+     *
      * The model must be or extend `Spatie\ModelStatus\Status`.
      */
     'status_model' => Spatie\ModelStatus\Status::class,
@@ -192,10 +192,10 @@ $model->forceSetStatus('invalid-status-name');
 
 ### Check if status has been assigned
 
-You can check if a specific status has been set on the model at any time by using the `hasStatus` method:
+You can check if a specific status has been set on the model at any time by using the `hasEverHadStatus` method:
 
 ```php
-$model->hasStatus('status 1');
+$model->hasEverHadStatus('status 1');
 ```
 
 ### Delete status from model
@@ -249,10 +249,10 @@ class StatusUpdated
 
 ### Custom model and migration
 
-You can change the model used by specifying a class name in the `status_model` key of the `model-status` config file. 
+You can change the model used by specifying a class name in the `status_model` key of the `model-status` config file.
 
-You can change the column name used in the status table (`model_id` by default) when using a custom migration where you changed 
-that. In that case, simply change the `model_primary_key_attribute` key of the `model-status` config file. 
+You can change the column name used in the status table (`model_id` by default) when using a custom migration where you changed
+that. In that case, simply change the `model_primary_key_attribute` key of the `model-status` config file.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,32 @@ You may bypass validation with the `forceSetStatus` method:
 $model->forceSetStatus('invalid-status-name');
 ```
 
+
+### Check if status has been assigned
+
+You can check if a specific status has been set on the model at any time by using the `hasStatus` method:
+
+```php
+$model->hasStatus('status 1');
+```
+
+### Delete status from model
+
+You can delete any given status that has been set on the model at any time by using the `deleteStatus` method:
+
+Delete single status from model:
+
+```php
+$model->deleteStatus('status 1');
+```
+
+Delete multiple statuses from model at once:
+
+```php
+$model->deleteStatus(['status 1', 'status 2']);
+```
+
+
 ### Events
 
 The`Spatie\ModelStatus\Events\StatusUpdated`  event will be dispatched when the status is updated.

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -55,7 +55,7 @@ trait HasStatuses
         return $statuses->whereIn('name', $names)->first();
     }
 
-    public function hasStatus($name): bool
+    public function hasEverHadStatus($name): bool
     {
         $statuses = $this->relationLoaded('statuses') ? $this->statuses : $this->statuses();
 

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -26,7 +26,7 @@ trait HasStatuses
 
     public function setStatus(string $name, ?string $reason = null): self
     {
-        if (!$this->isValidStatus($name, $reason)) {
+        if (! $this->isValidStatus($name, $reason)) {
             throw InvalidStatus::create($name);
         }
 
@@ -59,7 +59,7 @@ trait HasStatuses
     {
         $statuses = $this->relationLoaded('statuses') ? $this->statuses : $this->statuses();
 
-        return ($statuses->where('name', $name)->count() > 0);
+        return $statuses->where('name', $name)->count() > 0;
     }
 
     public function deleteStatus(...$names)
@@ -126,7 +126,7 @@ trait HasStatuses
 
     public function getStatusAttribute(): string
     {
-        return (string)$this->latestStatus();
+        return (string) $this->latestStatus();
     }
 
     public function forceSetStatus(string $name, ?string $reason = null): self

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -11,6 +11,7 @@ use Spatie\ModelStatus\Tests\Models\CustomModelKeyStatusModel;
 
 class HasStatusesTest extends TestCase
 {
+    /** @var TestModel */
     protected $testModel;
 
     protected function setUp(): void
@@ -137,6 +138,53 @@ class HasStatusesTest extends TestCase
         );
 
         $this->assertNull($this->testModel->latestStatus('non existing status'));
+    }
+
+    /** @test */
+    public function it_will_return_true_if_specific_status_is_found()
+    {
+        $this->testModel->setStatus('status 1');
+
+        $this->assertTrue($this->testModel->hasStatus('status 1'));
+    }
+
+    /** @test */
+    public function it_will_return_false_if_specific_status_is_not_found()
+    {
+        $this->testModel->setStatus('status 1');
+
+        $this->assertFalse($this->testModel->hasStatus('status 2'));
+    }
+
+    /** @test */
+    public function it_can_delete_a_specific_status()
+    {
+        $this->testModel->setStatus('status to delete');
+
+        $this->assertEquals(1, $this->testModel->statuses()->count());
+        $this->testModel->deleteStatus('status to delete');
+        $this->assertEquals(0, $this->testModel->statuses()->count());
+    }
+
+    /** @test */
+    public function it_can_delete_a_multiple_statuses_at_once()
+    {
+        $this->testModel->setStatus('status to delete 1')
+            ->setStatus('status to delete 2');
+
+        $this->assertEquals(2, $this->testModel->statuses()->count());
+        $this->testModel->deleteStatus('status to delete 1', 'status to delete 2');
+        $this->assertEquals(0, $this->testModel->statuses()->count());
+    }
+
+    /** @test */
+    public function it_will_keep_status_when_invalid_delete_status_is_given()
+    {
+        $this->testModel->setStatus('status to delete');
+
+        $this->assertEquals(1, $this->testModel->statuses()->count());
+        $this->testModel->deleteStatus();
+        $this->assertEquals(1, $this->testModel->statuses()->count());
     }
 
     /** @test */

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -145,7 +145,7 @@ class HasStatusesTest extends TestCase
     {
         $this->testModel->setStatus('status 1');
 
-        $this->assertTrue($this->testModel->hasStatus('status 1'));
+        $this->assertTrue($this->testModel->hasEverHadStatus('status 1'));
     }
 
     /** @test */
@@ -153,7 +153,7 @@ class HasStatusesTest extends TestCase
     {
         $this->testModel->setStatus('status 1');
 
-        $this->assertFalse($this->testModel->hasStatus('status 2'));
+        $this->assertFalse($this->testModel->hasEverHadStatus('status 2'));
     }
 
     /** @test */


### PR DESCRIPTION
This commit adds two new helpful methods:

**Check if a specific status has been set at any point on model**
Sometimes it is useful to not only have a method to retrieve the latest status but also to be able to check if any given status has been set at any given time on the model.

**Delete one or more status from the model**
Sometimes it is useful to be able to delete a given status from the history. Think temporary statuses like a flag that can be removed after a specific period of time.