### PR TITLE
Remove statuses on model delete

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -10,9 +10,17 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Spatie\ModelStatus\Events\StatusUpdated;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
+use Illuminate\Database\Eloquent\Model;
 
 trait HasStatuses
 {
+    public static function bootHasStatuses()
+    {
+        static::deleted(function (Model $deletedModel) {
+            $deletedModel->statuses()->delete();
+        });
+    }
+
     public function statuses(): MorphMany
     {
         return $this->morphMany($this->getStatusModelClassName(), 'model', 'model_type', $this->getModelKeyColumnName())

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -320,4 +320,23 @@ class HasStatusesTest extends TestCase
         $this->assertEquals('pending', $model->status);
         $this->assertEquals($model->id, $model->status()->model_id);
     }
+
+    /** @test */
+    public function it_can_remove_statuses_on_model_delete()
+    {
+        $this->testModel->setStatus('pending');
+        $this->testModel->setStatus('ready');
+
+        $this->assertEquals(2, $this->testModel->statuses()->count());
+
+        $this->testModel->delete();
+
+        $this->assertEquals(0, $this->testModel->statuses()->count());
+    }
+
+    /** @test */
+    public function it_can_remove_model_without_statuses()
+    {
+        $this->assertTrue($this->testModel->delete());
+    }
 }


### PR DESCRIPTION
This PR is removing all attached statuses on model delete since we don't need them anymore if the model doesn't exist. Hopefully, this will work for you.

Let me know if you have any questions or suggestions.

Thanks!