### PR TITLE
Adding a dispatch flag that could be use to control the status update…

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -24,13 +24,13 @@ trait HasStatuses
         return $this->latestStatus();
     }
 
-    public function setStatus(string $name, ?string $reason = null): self
+    public function setStatus(string $name, ?string $reason = null, $dispatch = true): self
     {
         if (! $this->isValidStatus($name, $reason)) {
             throw InvalidStatus::create($name);
         }
 
-        return $this->forceSetStatus($name, $reason);
+        return $this->forceSetStatus($name, $reason, $dispatch);
     }
 
     public function isValidStatus(string $name, ?string $reason = null): bool
@@ -129,7 +129,7 @@ trait HasStatuses
         return (string) $this->latestStatus();
     }
 
-    public function forceSetStatus(string $name, ?string $reason = null): self
+    public function forceSetStatus(string $name, ?string $reason = null, $dispatch = true): self
     {
         $oldStatus = $this->latestStatus();
 
@@ -138,7 +138,9 @@ trait HasStatuses
             'reason' => $reason,
         ]);
 
-        event(new StatusUpdated($oldStatus, $newStatus, $this));
+        if ($dispatch) {
+            event(new StatusUpdated($oldStatus, $newStatus, $this));
+        }
 
         return $this;
     }

--- a/tests/Events/StatusEventsTest.php
+++ b/tests/Events/StatusEventsTest.php
@@ -36,3 +36,13 @@ it('fires an event when status changes', function () {
         }
     );
 });
+
+it('doesn\'t fire status updated event when explicity asked not to dispatch', function() {
+    $this->testModel->setStatus('pending', 'waiting for action');
+
+    Event::fake();
+
+    $this->testModel->setStatus('status a', 'Reason a', /*dispatch=*/false);
+
+    Event::assertNotDispatched(StatusUpdated::class);
+});


### PR DESCRIPTION
I had a use case that might go for a infinite loop if the code is written without caution, so maybe having a dispatch flag might be useful for the api users.