### PR TITLE
getStatusNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ You can also get latest status of a given name:
 ```php
 $model->latestStatus('pending'); // returns an instance of `Spatie\ModelStatus\Status` that has the name `pending`
 ```
+Get all available status names for the model.
+
+```php
+$statusNames = $model->getStatusNames(); // returns a collection of all available status names.
+```
 
 The following examples will return statusses of type `status 1` or `status 2`, whichever is latest.
 

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use \Illuminate\Support\Collection;
 use Spatie\ModelStatus\Events\StatusUpdated;
 use Spatie\ModelStatus\Exceptions\InvalidStatus;
 
@@ -177,5 +178,16 @@ trait HasStatuses
         }
 
         return parent::__get($key);
+    }
+    /* 
+    * Get all available status names for the model.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getStatusNames(): Collection
+    {
+        $statusModel = app($this->getStatusModelClassName());
+
+        return $statusModel->pluck('name');
     }
 }

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -184,7 +184,7 @@ trait HasStatuses
      *
      * @return \Illuminate\Support\Collection
      */
-    protected function getStatusNames(): Collection
+    public function getStatusNames(): Collection
     {
         $statusModel = app($this->getStatusModelClassName());
 

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -237,3 +237,30 @@ it('uses the default relationship id column when configuration value is', functi
     expect($model->status)->toEqual('pending')
         ->and($model->status()->model_id)->toEqual($model->id);
 });
+
+it('returns all available status names', function () {
+
+    $model = TestModel::create(['name' => 'model1']);
+    // Set up some test statuses
+    $model->setStatus('status1');
+    $model->setStatus('status2');
+    $model->setStatus('status3');
+
+    // Get the status names
+    $statusNames = $model->getStatusNames();
+
+    // Assert the returned status names
+    expect($statusNames)->toContain('status1')
+        ->toContain('status2')
+        ->toContain('status3');
+});
+
+it('returns an empty collection when there are no statuses', function () {
+    $model = TestModel::create(['name' => 'model1']);
+
+    // Get the status names
+    $statusNames = $model->getStatusNames();
+
+    // Assert the returned status names
+    expect($statusNames)->toBeEmpty();
+});


### PR DESCRIPTION
I have created this pull request before but faced an issue
Get all available status names for the model.

```php
$statusNames = $model->getStatusNames(); // returns a collection of all available status names.
```