### PR TITLE
Update HasStatuses.php

### DIFF
--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -179,6 +179,21 @@ trait HasStatuses
 
         return parent::__get($key);
     }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function __isset($key): bool
+    {
+        if ($key === $this->getStatusAttributeName()) {
+            return !is_null( $this->latestStatus() );
+        }
+
+        return parent::__isset($key);
+    }
+    
     /*
     * Get all available status names for the model.
      *


### PR DESCRIPTION
Need to define a **HasStatuses::__isset** method in order to use with **data_get()** helper function

Example : 

```php
$model = new MyModel;
$model->setStatus( 'my-status' );

$status = data_get( $model, 'status' ); // 'my-status'
```
Usefull when using spatie/laravel-html, overwise current status value is not retrieved

```php
{{ htm()->model( $model )->form('POST')->open() }}
    {{ html()->select( 'status', [ 'todo' => 'Need action', 'done' => 'Done' ] ) }}
{{ html()->form()->close() }}