### PR TITLE
feat: Add method to check if a model has never had a specific status

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ You can check if a specific status has been set on the model at any time by usin
 $model->hasEverHadStatus('status 1');
 ```
 
+### Check if status has never been assigned
+
+You can check if a specific status has never been set on the model at any time by using the `hasNeverHadStatus` method:
+
+```php
+$model->hasNeverHadStatus('status 1');
+```
+
 ### Delete status from model
 
 You can delete any given status that has been set on the model at any time by using the `deleteStatus` method:

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -55,11 +55,40 @@ trait HasStatuses
         return $statuses->whereIn('name', $names)->first();
     }
 
+    /**
+     * Check if the model has ever had a status with the given name.
+     *
+     * This method determines whether the current model instance has ever had a status
+     * with the specified name.
+     *
+     * @param string $name The name of the status to check for.
+     *
+     * @return bool Returns true if the model has ever had the status with the given name,
+     *              otherwise returns false.
+     */
     public function hasEverHadStatus($name): bool
     {
         $statuses = $this->relationLoaded('statuses') ? $this->statuses : $this->statuses();
 
         return $statuses->where('name', $name)->count() > 0;
+    }
+
+    /**
+     * Check if the model has never had a status with the given name.
+     *
+     * This method determines whether the current model instance has never had a status
+     * with the specified name.
+     *
+     * @param string $name The name of the status to check for.
+     *
+     * @return bool Returns true if the model has never had the status with the given name,
+     *              otherwise returns false.
+     */
+    public function hasNeverHadStatus($name): bool
+    {
+        $statuses = $this->relationLoaded('statuses') ? $this->statuses : $this->statuses();
+
+        return $statuses->where('name', $name)->count() === 0;
     }
 
     public function deleteStatus(...$names)

--- a/src/HasStatuses.php
+++ b/src/HasStatuses.php
@@ -77,7 +77,7 @@ trait HasStatuses
      * Check if the model has never had a status with the given name.
      *
      * This method determines whether the current model instance has never had a status
-     * with the specified name.
+     * with the specified name by negating the result of hasEverHadStatus.
      *
      * @param string $name The name of the status to check for.
      *
@@ -86,9 +86,7 @@ trait HasStatuses
      */
     public function hasNeverHadStatus($name): bool
     {
-        $statuses = $this->relationLoaded('statuses') ? $this->statuses : $this->statuses();
-
-        return $statuses->where('name', $name)->count() === 0;
+        return !$this->hasEverHadStatus($name);
     }
 
     public function deleteStatus(...$names)

--- a/tests/HasStatusesTest.php
+++ b/tests/HasStatusesTest.php
@@ -109,6 +109,16 @@ it('will return `false` if specific status is not found')
     ->expect(fn () => $this->testModel->hasEverHadStatus('status 2'))
     ->toBeFalse();
 
+it('will return `false` if specific status is found')
+    ->tap(fn () => $this->testModel->setStatus('status 1'))
+    ->expect(fn () => $this->testModel->hasNeverHadStatus('status 1'))
+    ->toBeFalse();
+
+it('will return `true` if specific status is not found')
+    ->tap(fn () => $this->testModel->setStatus('status 1'))
+    ->expect(fn () => $this->testModel->hasNeverHadStatus('status 2'))
+    ->toBeTrue();
+
 it('can delete a specific status', function () {
     $this->testModel->setStatus('status to delete');
 


### PR DESCRIPTION
- Added `hasNeverHadStatus($name): bool` method to determine if the model has never had a status with the given name.
- Included PHPDoc comments for both `hasEverHadStatus($name): bool` and `hasNeverHadStatus($name): bool` methods.
- Added tests for `hasNeverHadStatus` method:
  - Test to return `false` if the specific status is found.
  - Test to return `true` if the specific status is not found.

This contribution introduces the inverse of the `hasEverHadStatus` function and improves documentation.